### PR TITLE
Add interfaces to song, player, and notification APIs

### DIFF
--- a/src/screens/CapoConfirmSend.js
+++ b/src/screens/CapoConfirmSend.js
@@ -28,9 +28,7 @@ import { HeaderBackButton } from 'react-navigation';
 import { Location, Permissions } from 'expo';
 
 import CapoMessageSchema from '../data/capo_message_schema';
-import { HYMNAL_ADDRESS } from '../config/server';
-
-const CAPO_MESSAGE_ENDPOINT = HYMNAL_ADDRESS + '/api/notification';
+import RemoteNotifications from '../server_store/RemoteNotifications';
 
 @withNavigation
 export default class CapoConfirmSend extends React.Component {
@@ -179,39 +177,31 @@ export default class CapoConfirmSend extends React.Component {
     CapoMessageSchema.song = state.currentSong;
     //console.log('---- object to wrap in a message to server ----\n', CapoMessageSchema);
 
-    fetch(CAPO_MESSAGE_ENDPOINT, {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        sender: CapoMessageSchema.sender,
-        send_time: CapoMessageSchema.send_time,
-        sender_latitude: CapoMessageSchema.sender_latitude,
-        sender_longitude: CapoMessageSchema.sender_longitude,
-        message: '',
-        push: pushFlag,
-        announcement: undefined,
-        song: {
-          category: CapoMessageSchema.song.category,
-          create_time: CapoMessageSchema.song.create_time,
-          update_time: CapoMessageSchema.song.update_time,
-          title: CapoMessageSchema.song.title,
-          tags: CapoMessageSchema.song.tags,
-          lyrics: CapoMessageSchema.song.lyrics,
-          tbd_various_boolean_flags:
-            CapoMessageSchema.song.tbd_various_boolean_flags,
-          reference_title: CapoMessageSchema.song.reference_title,
-          reference_link: CapoMessageSchema.song.reference_link,
-          instructions: CapoMessageSchema.song.instructions,
-          player_id: CapoMessageSchema.song.player_id,
-          override_html: CapoMessageSchema.song.override_html,
-          delete_local: CapoMessageSchema.song.delete_local
-        }
-      })
+    RemoteNotifications.create({
+      sender: CapoMessageSchema.sender,
+      send_time: CapoMessageSchema.send_time,
+      sender_latitude: CapoMessageSchema.sender_latitude,
+      sender_longitude: CapoMessageSchema.sender_longitude,
+      message: '',
+      push: pushFlag,
+      announcement: undefined,
+      song: {
+        category: CapoMessageSchema.song.category,
+        create_time: CapoMessageSchema.song.create_time,
+        update_time: CapoMessageSchema.song.update_time,
+        title: CapoMessageSchema.song.title,
+        tags: CapoMessageSchema.song.tags,
+        lyrics: CapoMessageSchema.song.lyrics,
+        tbd_various_boolean_flags:
+          CapoMessageSchema.song.tbd_various_boolean_flags,
+        reference_title: CapoMessageSchema.song.reference_title,
+        reference_link: CapoMessageSchema.song.reference_link,
+        instructions: CapoMessageSchema.song.instructions,
+        player_id: CapoMessageSchema.song.player_id,
+        override_html: CapoMessageSchema.song.override_html,
+        delete_local: CapoMessageSchema.song.delete_local
+      }
     })
-      .then(response => response.json())
       .then(responseJson => {
         // this is the output from the server for sending our capo_message
         console.log(JSON.stringify(responseJson));

--- a/src/server_store/ApiClient.js
+++ b/src/server_store/ApiClient.js
@@ -1,0 +1,17 @@
+import { HYMNAL_ADDRESS } from '../config/server';
+import ApiError from './ApiError';
+import React from 'react';
+
+export default class ApiClient {
+  constructor() {
+  }
+
+  async doRequest(resource, options = {}) {
+    let url = `${HYMNAL_ADDRESS}/api/${resource}`;
+    let response = await fetch(url, options);
+    if (!response.ok) {
+      throw new ApiError(`Request to ${url} returned error: ${response.status} ${response.statusText}`);
+    }
+    return response;
+  }
+};

--- a/src/server_store/ApiError.js
+++ b/src/server_store/ApiError.js
@@ -1,0 +1,17 @@
+export default class ApiError extends Error {
+    constructor(message, innerError = null, ...args) {
+        // For most exceptions, it's sufficient to just provide a message and
+        // inner exception (if there is one), so make those the first two
+        // arguments. Then pass (message, fileName, lineNumber) to Error().
+        //
+        // Also, Expo doesn't make use of .toString() overrides for formatting
+        // exception messages, so preformat .message here.
+        let extendedMessage = message + (innerError ? `:\n\n${innerError}` : '');
+        super(...[extendedMessage, args]);
+
+        this.innerError = innerError;
+        if (Error.captureStackTrace) {
+          Error.captureStackTrace(this, ApiError);
+        }
+    }
+};

--- a/src/server_store/RemoteNotifications.js
+++ b/src/server_store/RemoteNotifications.js
@@ -54,6 +54,7 @@ export default class RemoteNotifications extends ApiClient {
         },
         body: JSON.stringify(notification)
       });
+      return await response.json();
     }
     catch (error) {
       throw new ApiError(`Error updating notification with id ${id} on server`, error);

--- a/src/server_store/RemoteNotifications.js
+++ b/src/server_store/RemoteNotifications.js
@@ -1,0 +1,71 @@
+import ApiClient from './ApiClient';
+import ApiError from './ApiError';
+
+export default class RemoteNotifications extends ApiClient {
+  constructor(...args) {
+    super(...args);
+  }
+
+  async getLast() {
+    try {
+      let response = await this.doRequest('notifications/last');
+      return response.status == 204
+        ? null
+        : await response.json();
+    }
+    catch (error) {
+      throw new ApiError("Error fetching last notification from server", error);
+    }
+  }
+
+  async get(id) {
+    let resource = id === undefined ? 'notifications' : `notification/${id}`;
+    try {
+      let response = await this.doRequest(resource);
+      return await response.json();
+    }
+    catch (error) {
+      throw new ApiError(`Error fetching ${resource} from server`, error);
+    }
+  }
+
+  async create(notification) {
+    try {
+      let response = await this.doRequest('notification', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(notification)
+      });
+      return await response.json();
+    }
+    catch (error) {
+      throw new ApiError('Error creating new notification on server', error);
+    }
+  }
+
+  async update(id, notification) {
+    try {
+      let response = await this.doRequest(`notification/${id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(notification)
+      });
+    }
+    catch (error) {
+      throw new ApiError(`Error updating notification with id ${id} on server`, error);
+    }
+  }
+
+  async remove(id) {
+    try {
+      await this.doRequest(`notifications/${id}`, { method: 'DELETE' });
+    }
+    catch (error) {
+      throw new ApiError(`Error deleting notification with id ${id} from server`, error);
+    }
+  }
+};

--- a/src/server_store/RemotePlayers.js
+++ b/src/server_store/RemotePlayers.js
@@ -1,0 +1,58 @@
+import ApiClient from './ApiClient';
+import ApiError from './ApiError';
+
+export default class RemotePlayers extends ApiClient {
+  constructor(...args) {
+    super(...args);
+  }
+
+  async get(id) {
+    let resource = id === undefined ? 'players' : `player/${id}`;
+    try {
+      let response = await this.doRequest(resource);
+      return await response.json();
+    }
+    catch (error) {
+      throw new ApiError(`Error fetching ${resource} from server`, error);
+    }
+  }
+
+  async create(player) {
+    try {
+      let response = await this.doRequest('player', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(player)
+      });
+    }
+    catch (error) {
+      throw new ApiError('Error creating new player on server', error);
+    }
+  }
+
+  async update(id, player) {
+    try {
+      let response = await this.doRequest(`player/${id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(player)
+      });
+    }
+    catch (error) {
+      throw new ApiError(`Error updating player with id ${id} on server`, error);
+    }
+  }
+
+  async remove(id) {
+    try {
+      await this.doRequest(`players/${id}`, { method: 'DELETE' });
+    }
+    catch (error) {
+      throw new ApiError(`Error deleting player with id ${id} from server`, error);
+    }
+  }
+};

--- a/src/server_store/RemotePlayers.js
+++ b/src/server_store/RemotePlayers.js
@@ -26,6 +26,7 @@ export default class RemotePlayers extends ApiClient {
         },
         body: JSON.stringify(player)
       });
+      return await response.json();
     }
     catch (error) {
       throw new ApiError('Error creating new player on server', error);
@@ -41,6 +42,7 @@ export default class RemotePlayers extends ApiClient {
         },
         body: JSON.stringify(player)
       });
+      return await response.json();
     }
     catch (error) {
       throw new ApiError(`Error updating player with id ${id} on server`, error);

--- a/src/server_store/RemoteSongs.js
+++ b/src/server_store/RemoteSongs.js
@@ -28,6 +28,7 @@ export default class RemoteSongs extends ApiClient {
         },
         body: JSON.stringify(song)
       });
+      return await response.json();
     }
     catch (error) {
       throw new ApiError('Error creating new song on server', error);
@@ -43,6 +44,7 @@ export default class RemoteSongs extends ApiClient {
         },
         body: JSON.stringify(song)
       });
+      return await response.json();
     }
     catch (error) {
       throw new ApiError(`Error updating song with id ${id} on server`, error);

--- a/src/server_store/RemoteSongs.js
+++ b/src/server_store/RemoteSongs.js
@@ -1,0 +1,60 @@
+import ApiClient from './ApiClient';
+import ApiError from './ApiError';
+
+export default class RemoteSongs extends ApiClient {
+  constructor(...args) {
+    super(...args);
+  }
+
+  async get(id) {
+    let resource = id === undefined ? 'songs' : `songs/${id}`;
+    let description = id === undefined ? 'all songs' : `song with id ${id}`;
+
+    try {
+      let response = await this.doRequest(resource);
+      return await response.json();
+    }
+    catch (error) {
+      throw new ApiError(`Error fetching ${description} from server`, error);
+    }
+  }
+
+  async create(song) {
+    try {
+      let response = await this.doRequest('song', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(song)
+      });
+    }
+    catch (error) {
+      throw new ApiError('Error creating new song on server', error);
+    }
+  }
+
+  async update(id, song) {
+    try {
+      let response = await this.doRequest(`song/${id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(song)
+      });
+    }
+    catch (error) {
+      throw new ApiError(`Error updating song with id ${id} on server`, error);
+    }
+  }
+
+  async remove(id) {
+    try {
+      await this.doRequest(`songs/${id}`, { method: 'DELETE' });
+    }
+    catch (error) {
+      throw new ApiError(`Error deleting song with id ${id} from server`, error);
+    }
+  }
+};


### PR DESCRIPTION
Adds a Fetch wrapper for interacting with the hymnal server API, as well
as subclasses for songs, player info, and notifications. The wrapper is
bare-bones right now, but it (hopefully) makes our job easier later once
the server requires authentication for certain operations.

Minimal example for fetching the song database:

```javascript
import RemoteSongs from './src/server_store/RemoteSongs';
var all_songs = await new RemoteSongs().get();
```

This also updates the notification-sending code to use the new class.