### PR TITLE
Refactor navigation

### DIFF
--- a/App.js
+++ b/App.js
@@ -131,12 +131,10 @@ export default class App extends React.Component {
 
       // Maybe set app state and do something with it that way?
       // this.setState({ notification: notification });
-
     } else if (notification.origin === 'received') {
       // notification was received, either app was already open or it just opened up but not from the notification
       // no way to tell which?
       // console.log('RECEIVED notification', notification.data.song.title);
-
       // We don't necessarily want to do anything in this case
     }
   };
@@ -157,6 +155,7 @@ export default class App extends React.Component {
     return (
       <View style={{ flex: 1 }}>
         <Navigation />
+        <StatusBar barStyle="light-content" />
       </View>
     );
   }

--- a/package.json
+++ b/package.json
@@ -23,13 +23,14 @@
     "moment-timezone": "^0.5.14",
     "ramda": "^0.25.0",
     "react": "16.0.0",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-23.0.0.tar.gz",
+    "react-native":
+      "https://github.com/expo/react-native/archive/sdk-23.0.0.tar.gz",
     "react-native-animatable": "^1.2.4",
     "react-native-deck-swiper": "^1.4.8",
     "react-native-fade-in-image": "1.3.0",
     "react-native-read-more-text": "^1.0.0",
     "react-native-resource-saving-container": "^1.0.2",
-    "react-navigation": "1.0.0-beta.19"
+    "react-navigation": "1.5.11"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",

--- a/src/Navigation.js
+++ b/src/Navigation.js
@@ -1,66 +1,10 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import {
-  TabRouter,
-  TabNavigator,
-  StackNavigator,
-  createNavigator,
-  createNavigationContainer
-} from 'react-navigation';
-import NavigatorTypes from 'react-navigation/src/navigators/NavigatorTypes';
-import withCachedChildNavigation from 'react-navigation/src/withCachedChildNavigation';
-import SceneView from 'react-navigation/src/views/SceneView';
-import {
-  BackHandler,
-  Platform,
-  Image,
-  Text,
-  StyleSheet,
-  StatusBar,
-  View
-} from 'react-native';
-import { Constants } from 'expo';
-import { TabViewAnimated } from 'react-native-tab-view';
-import {
-  DrawerLayoutAndroid,
-  BorderlessButton,
-  RectButton
-} from 'react-native-gesture-handler';
-import DrawerLayout from 'react-native-gesture-handler/DrawerLayout';
-import ResourceSavingContainer from 'react-native-resource-saving-container';
-import hoistStatics from 'hoist-non-react-statics';
-
-import { Colors, FontSizes, Layout } from './constants';
+import { Dimensions } from 'react-native';
+import { StackNavigator, DrawerNavigator } from 'react-navigation';
 import Screens from './screens';
-import Fools from './fools';
-import TabBarBottom from './components/TabBarBottom';
-import { SemiBoldText, BoldText } from './components/StyledText';
+import CustomDrawer from './components/CustomDrawer';
 
-import state from './state';
-
-const DrawerComponent =
-  Platform.OS === 'android' ? DrawerLayoutAndroid : DrawerLayout;
-
-export function connectDrawerButton(WrappedComponent) {
-  const ConnectedDrawerButton = (props, context) => {
-    return (
-      <WrappedComponent
-        {...props}
-        openDrawer={context.openDrawer}
-        closeDrawer={context.closeDrawer}
-        toggleDrawer={context.toggleDrawer}
-      />
-    );
-  };
-
-  ConnectedDrawerButton.contextTypes = {
-    openDrawer: PropTypes.func,
-    closeDrawer: PropTypes.func,
-    toggleDrawer: PropTypes.func
-  };
-
-  return hoistStatics(ConnectedDrawerButton, WrappedComponent);
-}
+const { width: deviceWidth } = Dimensions.get('window');
 
 const DefaultStackConfig = {
   cardStyle: {
@@ -83,7 +27,12 @@ const SongbookNavigation = StackNavigator(
       screen: Screens.Songbook
     }
   },
-  DefaultStackConfig
+  {
+    ...DefaultStackConfig,
+    navigationOptions: {
+      drawerLabel: 'SONGBOOK'
+    }
+  }
 );
 
 const RosterNavigation = StackNavigator(
@@ -92,16 +41,30 @@ const RosterNavigation = StackNavigator(
       screen: Screens.Roster
     }
   },
-  DefaultStackConfig
+  {
+    ...DefaultStackConfig,
+    navigationOptions: {
+      drawerLabel: 'ROSTER'
+    }
+  }
 );
 
 const CapoHomeNavigation = StackNavigator(
   {
+    CapoLogin: { screen: Screens.CapoLogin },
     CapoHome: {
       screen: Screens.CapoHome
-    }
+    },
+    CapoSelectSong: { screen: Screens.CapoSelectSong },
+    CapoConfirmSend: { screen: Screens.CapoConfirmSend },
+    CapoComposeSong: { screen: Screens.CapoComposeSong }
   },
-  DefaultStackConfig
+  {
+    ...DefaultStackConfig,
+    navigationOptions: {
+      drawerLabel: 'CAPO DASHBOARD'
+    }
+  }
 );
 
 const AboutNavigation = StackNavigator(
@@ -110,344 +73,32 @@ const AboutNavigation = StackNavigator(
       screen: Screens.About
     }
   },
-  DefaultStackConfig
-);
-
-const DatingNavigation = StackNavigator(
   {
-    Dating: {
-      screen: Fools.Dating
+    ...DefaultStackConfig,
+    navigationOptions: {
+      drawerLabel: 'ABOUT'
     }
-  },
-  DefaultStackConfig
+  }
 );
 
-const DrawerRouteConfig = {
-  Home: { screen: Screens.Home, title: 'Home' },
-  Songbook: { screen: SongbookNavigation, title: 'Songbook' },
-  Roster: { screen: RosterNavigation, title: 'Roster' },
-  CapoHome: { screen: CapoHomeNavigation, title: 'Capo Dashboard' },
-  About: { screen: AboutNavigation, title: 'About' },
-};
-
-const DrawerRouter = TabRouter(DrawerRouteConfig);
-
-class DrawerScene extends React.PureComponent {
-  state = {
-    visible: true
-  };
-
-  setVisible = visible => {
-    this.setState({ visible });
-  };
-
-  render() {
-    const { route, screenProps } = this.props;
-    const childNavigation = this.props.childNavigationProps[route.key];
-    const ScreenComponent = DrawerRouter.getComponentForRouteName(
-      route.routeName
-    );
-
-    return (
-      <ResourceSavingContainer
-        style={{ flex: 1, overflow: 'hidden' }}
-        visible={this.state.visible}
-      >
-        <SceneView
-          screenProps={screenProps}
-          component={ScreenComponent}
-          navigation={childNavigation}
-        />
-      </ResourceSavingContainer>
-    );
+const Drawer = DrawerNavigator(
+  {
+    Home: { screen: Screens.Home },
+    Songbook: { screen: SongbookNavigation },
+    Roster: { screen: RosterNavigation },
+    CapoHome: { screen: CapoHomeNavigation },
+    About: { screen: AboutNavigation }
+  },
+  {
+    contentComponent: props => <CustomDrawer {...props} />,
+    drawerWidth: deviceWidth - 80
   }
-}
-
-const DRAWER_WIDTH = Math.min(Math.max(Layout.window.width - 80, 280), 350);
-@withCachedChildNavigation
-class DrawerView extends React.Component {
-  _isDrawerOpen = false;
-  _scenes = {};
-
-  static childContextTypes = {
-    openDrawer: PropTypes.func,
-    closeDrawer: PropTypes.func,
-    toggleDrawer: PropTypes.func
-  };
-
-  getChildContext() {
-    const openDrawer = options => this._drawerRef.openDrawer(options);
-    const closeDrawer = options => this._drawerRef.closeDrawer(options);
-    const toggleDrawer = options =>
-      this._isDrawerOpen ? closeDrawer(options) : openDrawer(options);
-
-    return {
-      openDrawer,
-      closeDrawer,
-      toggleDrawer
-    };
-  }
-
-  componentWillMount() {
-    if (Platform.OS === 'ios') {
-      return;
-    }
-
-    // Dumb hack to have our listener take priority over built in listener
-    setTimeout(() => {
-      BackHandler.addEventListener('hardwareBackPress', this._onBackPress);
-    }, 800);
-  }
-
-  componentWillUnmount() {
-    BackHandler.removeEventListener('hardwareBackPress', this._onBackPress);
-  }
-
-  _onBackPress = () => {
-    if (this._drawerIsOpen) {
-      this._drawerRef.closeDrawer();
-      return true;
-    }
-
-    return false;
-  };
-
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.navigation.state !== this.props.navigation.state) {
-      const currentRoute = this.props.navigation.state.routes[
-        this.props.navigation.state.index
-      ];
-      const nextRoute =
-        nextProps.navigation.state.routes[nextProps.navigation.state.index];
-
-      if (currentRoute.key !== nextRoute.key) {
-        this._updateVisibility(currentRoute, nextRoute);
-      }
-    }
-  }
-
-  _renderScene = ({ route }) => {
-    return (
-      <DrawerScene
-        ref={view => {
-          this._scenes[route.key] = view;
-        }}
-        {...this.props}
-        route={route}
-      />
-    );
-  };
-
-  render() {
-    return (
-      <View style={styles.container}>
-        <DrawerComponent
-          ref={view => {
-            this._drawerRef = view;
-          }}
-          onDrawerOpen={() => {
-            this._drawerIsOpen = true;
-          }}
-          onDrawerClose={() => {
-            this._drawerIsOpen = false;
-          }}
-          drawerWidth={DRAWER_WIDTH}
-          keyboardDismissMode="on-drag"
-          edgeWidth={60}
-          drawerPosition={DrawerComponent.positions.Left}
-          drawerType="front"
-          drawerBackgroundColor="#333333"
-          renderNavigationView={this._renderNavigationView}
-        >
-          <View style={{ flex: 1 }} key="container">
-            <View
-              key="tab-view-container"
-              style={{
-                flex: 1,
-                paddingTop:
-                  Platform.OS === 'android' ? Constants.statusBarHeight : 0
-              }}
-            >
-              <TabViewAnimated
-                navigationState={this.props.navigation.state}
-                animationEnabled={false}
-                renderScene={this._renderScene}
-                onIndexChange={this._navigateToScreen}
-                swipeEnabled={false}
-                lazy
-              />
-            </View>
-            <View
-              key="status-bar-underlay"
-              style={{
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                right: 0,
-                height:
-                  Platform.OS === 'android' ? Constants.statusBarHeight : 0,
-                backgroundColor: Colors.green
-              }}
-            />
-          </View>
-        </DrawerComponent>
-
-        <StatusBar barStyle="light-content" />
-      </View>
-    );
-  }
-
-  _renderNavigationView = () => {
-    return (
-      <View style={styles.drawerContainer}>
-        <View style={styles.drawerHeader}>
-          <Image
-            source={require('./assets/drawer-hero-background.png')}
-            style={{
-              height: 140 + Layout.notchHeight,
-              width: DRAWER_WIDTH,
-              resizeMode: 'cover'
-            }}
-          />
-          <View
-            style={[
-              StyleSheet.absoluteFill,
-              { backgroundColor: 'rgba(3, 46, 85, 0.57)' }
-            ]}
-          />
-          <View
-            style={[
-              StyleSheet.absoluteFill,
-              {
-                alignItems: 'center',
-                justifyContent: 'center',
-                paddingTop: Layout.notchHeight + 20
-              }
-            ]}
-          >
-            <Image
-              source={require('./assets/drawer-hero-logo.png')}
-              style={{
-                width: 200,
-                height: 50,
-                resizeMode: 'contain'
-              }}
-            />
-          </View>
-        </View>
-        <View style={styles.drawerButtons}>
-          {/* make sure the buttons here are in the same order as in route config */}
-          {this._renderButtons([
-            { route: 'Home', title: 'Home' },
-            { route: 'Songbook', title: 'Songbook' },
-            { route: 'Roster', title: 'Roster' },
-            { route: 'CapoHome', title: 'Capo Dashboard' },
-            { route: 'About', title: 'About' },
-          ])}
-        </View>
-      </View>
-    );
-  };
-
-  _renderButtons = buttonConfig => {
-    const selectedIndex = this.props.navigation.state.index;
-
-    return buttonConfig.map((config, i) => (
-      <DrawerButton
-        key={i}
-        onPress={() => this._navigateToScreen(i)}
-        selected={selectedIndex === i}
-      >
-        {config.title}
-      </DrawerButton>
-    ));
-  };
-
-  _updateVisibility = (currentRoute, nextRoute) => {
-    const currentScene = this._scenes[currentRoute.key];
-    const nextScene = this._scenes[nextRoute.key];
-
-    if (nextScene) {
-      nextScene.setVisible(true);
-    }
-    if (currentScene) {
-      currentScene.setVisible(false);
-    }
-  };
-
-  _navigateToScreen = index => {
-    this._drawerRef.closeDrawer();
-    const nextRoute = this.props.navigation.state.routes[index];
-    console.log(nextRoute.routeName);
-    if (nextRoute.routeName === 'CapoHome') {
-      if (state.unlocked === true) {
-        this.props.navigation.navigate('CapoHome');
-      } else {
-        this.props.navigation.navigate('CapoLogin');
-      }
-    } else {
-      this.props.navigation.navigate(nextRoute.routeName);
-    }
-  };
-}
-
-const DrawerNavigation = createNavigationContainer(
-  createNavigator(DrawerRouter, DrawerRouteConfig, {}, NavigatorTypes.TABS)(
-    props => <DrawerView {...props} />
-  )
 );
-
-class DrawerButton extends React.Component {
-  render() {
-    return (
-      <RectButton
-        onPress={this.props.onPress}
-        style={{
-          backgroundColor: this.props.selected
-            ? 'rgba(255,255,255,0.1)'
-            : '#333333'
-        }}
-      >
-        <View
-          style={{
-            height: 50,
-            width: DRAWER_WIDTH,
-            justifyContent: 'center',
-            paddingHorizontal: 5
-          }}
-        >
-          <SemiBoldText style={styles.drawerButtonText}>
-            {this.props.children.toUpperCase()}
-          </SemiBoldText>
-        </View>
-      </RectButton>
-    );
-  }
-}
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1
-  },
-  drawerButtonText: {
-    color: '#fff',
-    fontSize: FontSizes.normalButton,
-    padding: 10
-  },
-  drawerButtons: {
-    paddingTop: 0
-  },
-  drawerNavigationContainer: {}
-});
 
 export default StackNavigator(
   {
-    Primary: { screen: DrawerNavigation },
+    Drawer: { screen: Drawer },
     SingleSong: { screen: Screens.SingleSong },
-    CapoSelectSong: { screen: Screens.CapoSelectSong },
-    CapoLogin: { screen: Screens.CapoLogin },
-    CapoConfirmSend: { screen: Screens.CapoConfirmSend },
-    CapoComposeSong: { screen: Screens.CapoComposeSong },
     Player: { screen: Screens.Player }
   },
   {

--- a/src/components/CustomDrawer.js
+++ b/src/components/CustomDrawer.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Image, StyleSheet, View } from 'react-native';
+import { DrawerItems, NavigationActions, SafeAreaView } from 'react-navigation';
+import { Layout } from '../constants';
+import state from '../state';
+
+const CustomDrawer = props => (
+  <View style={styles.container}>
+    <View style={styles.drawerHeader}>
+      <Image
+        source={require('../assets/drawer-hero-background.png')}
+        style={styles.backgroundImage}
+      />
+      <View style={[StyleSheet.absoluteFill, styles.imageOverlay]} />
+      <View style={[StyleSheet.absoluteFill, styles.logoContainer]}>
+        <Image
+          source={require('../assets/drawer-hero-logo.png')}
+          style={styles.logoImage}
+        />
+      </View>
+    </View>
+    <DrawerItems
+      {...props}
+      activeBackgroundColor="rgba(255,255,255,0.1)"
+      labelStyle={{ color: 'white' }}
+      onItemPress={({ route, focused }) => {
+        if (route.routeName === 'CapoHome') {
+          if (state.unlocked === true) {
+            props.navigation.navigate('CapoHome');
+          } else {
+            props.navigation.navigate('CapoLogin');
+          }
+        } else {
+          props.onItemPress({ route });
+        }
+      }}
+    />
+  </View>
+);
+
+const styles = StyleSheet.create({
+  backgroundImage: {
+    height: 140 + Layout.notchHeight,
+    width: '100%',
+    resizeMode: 'cover'
+  },
+  container: {
+    flex: 1,
+    backgroundColor: '#333333'
+  },
+  imageOverlay: {
+    backgroundColor: 'rgba(3, 46, 85, 0.57)'
+  },
+  logoContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingTop: Layout.notchHeight + 20
+  },
+  logoImage: {
+    width: 200,
+    height: 50,
+    resizeMode: 'contain'
+  }
+});
+
+export default CustomDrawer;

--- a/src/components/MenuButton.js
+++ b/src/components/MenuButton.js
@@ -1,16 +1,18 @@
 import React from 'react';
 import { Platform } from 'react-native';
-import { connectDrawerButton } from '../Navigation';
+import { withNavigation } from 'react-navigation';
 import { BorderlessButton } from 'react-native-gesture-handler';
 import { Ionicons } from '@expo/vector-icons';
 import { Layout } from '../constants';
 
-@connectDrawerButton
+@withNavigation
 export default class MenuButton extends React.Component {
+  onPress = () => this.props.navigation.navigate('DrawerToggle');
+
   render() {
     return (
       <BorderlessButton
-        onPress={this.props.openDrawer}
+        onPress={this.onPress}
         style={{
           marginBottom: 2,
           marginRight: 5,
@@ -18,7 +20,7 @@ export default class MenuButton extends React.Component {
           marginLeft: 5,
           paddingHorizontal: 10,
           paddingVertical: 5,
-          alignSelf: 'flex-start',
+          alignSelf: 'flex-start'
         }}
         hitSlop={{ left: 30, top: 30, right: 30, bottom: 30 }}
       >

--- a/src/screens/CapoLogin.js
+++ b/src/screens/CapoLogin.js
@@ -8,21 +8,11 @@ import {
   TextInput
 } from 'react-native';
 import { RectButton } from 'react-native-gesture-handler';
-import FadeIn from 'react-native-fade-in-image';
 import { withNavigation } from 'react-navigation';
-import { NavigationActions } from 'react-navigation';
 import NavigationOptions from '../config/NavigationOptions';
-import { Ionicons } from '@expo/vector-icons';
-
 import state from '../state';
-
-import LoadingPlaceholder from '../components/LoadingPlaceholder';
-import { BoldText, RegularText, SemiBoldText } from '../components/StyledText';
-
-import NavigationBar from '../components/NavigationBar';
-import { Colors, FontSizes, Layout } from '../constants';
-import { Constants } from 'expo';
-import { HeaderBackButton } from 'react-navigation';
+import { BoldText, SemiBoldText } from '../components/StyledText';
+import { Colors, FontSizes } from '../constants';
 
 // TODO: Hard code password for now
 // Add top nav bar with Back button
@@ -35,64 +25,29 @@ import { HeaderBackButton } from 'react-navigation';
 @withNavigation
 export default class CapoLogin extends React.Component {
   static navigationOptions = {
-    title: 'Capo Login',
+    headerTitle: 'Capo Dashboard',
     ...NavigationOptions
   };
 
   render() {
     return (
-      <LoadingPlaceholder>
-        <View style={styles.container}>
-          <Text style={styles.instructions}>Enter password to unlock</Text>
-          <TextInput style={styles.textInput} autoFocus={true} onChangeText={this._setPassword} />
-          <ClipBorderRadius>
-            <RectButton
-              style={styles.bigButton}
-              onPress={this._handlePressSubmitButton}
-              underlayColor="#fff"
-            >
-              <SemiBoldText style={styles.bigButtonText}>Unlock</SemiBoldText>
-            </RectButton>
-          </ClipBorderRadius>
-          <NavigationBar
-            animatedBackgroundOpacity={1}
-            style={[
-              Platform.OS === 'android'
-                ? { height: Layout.headerHeight + Constants.statusBarHeight, flexDirection: 'row' }
-                : null,
-            ]}
-            renderLeftButton={() => (
-              <View
-                style={{
-                  // gross dumb things
-                  paddingTop: Platform.OS === 'android' ? 17 : 0,
-                  marginTop: Layout.notchHeight > 0 ? -5 : 0
-                }}
-              >
-                <HeaderBackButton
-                  onPress={() => this.props.navigation.goBack()}
-                  tintColor="#fff"
-                />
-              </View>
-            )}
-            renderTitle={() => (
-              <Text
-                style={{
-                  // gross dumb things
-                  paddingTop: Platform.OS === 'android' ? 17 : 0,
-                  marginTop: Layout.notchHeight > 0 ? -5 : 0,
-                  fontFamily: 'open-sans-bold',
-                  color: "#FFFFFF",
-                  fontSize: 20,
-                  paddingHorizontal: 0
-                }}
-              >
-                Capo Dashboard Locked
-              </Text>
-            )}
-          />
-        </View>
-      </LoadingPlaceholder>
+      <View style={styles.container}>
+        <Text style={styles.instructions}>Enter password to unlock</Text>
+        <TextInput
+          style={styles.textInput}
+          autoFocus={true}
+          onChangeText={this._setPassword}
+        />
+        <ClipBorderRadius>
+          <RectButton
+            style={styles.bigButton}
+            onPress={this._handlePressSubmitButton}
+            underlayColor="#fff"
+          >
+            <SemiBoldText style={styles.bigButtonText}>Unlock</SemiBoldText>
+          </RectButton>
+        </ClipBorderRadius>
+      </View>
     );
   }
 
@@ -127,7 +82,8 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     width: 100 + '%',
-    paddingBottom: 8, paddingTop: Layout.headerHeight + Constants.statusBarHeight
+    paddingBottom: 8,
+    paddingTop: 15
   },
   instructions: {
     fontSize: 18
@@ -135,26 +91,6 @@ const styles = StyleSheet.create({
   textInput: {
     fontSize: 18,
     padding: 8
-  },
-  error: {
-    color: '#FF0000'
-  },
-  button: {
-    backgroundColor: '#fff',
-    padding: 15,
-    ...Platform.select({
-      ios: {
-        borderRadius: 5,
-        backgroundColor: '#fff',
-        shadowColor: '#000',
-        shadowOpacity: 0.1,
-        shadowRadius: 4,
-        shadowOffset: { width: 2, height: 2 }
-      },
-      android: {
-        elevation: 3
-      }
-    })
   },
   bigButton: {
     backgroundColor: Colors.green,

--- a/src/screens/Home.js
+++ b/src/screens/Home.js
@@ -49,7 +49,7 @@ websites.forEach(item => {
           marginTop: 3, marginBottom: 3,
           marginLeft: 10, marginRight: 10,
           backgroundColor: 'transparent'
-        }}        
+        }}
       />
     </TouchableOpacity>
   );
@@ -58,6 +58,10 @@ websites.forEach(item => {
 class Home extends React.Component {
   state = {
     scrollY: new Animated.Value(0)
+  };
+
+  static navigationOptions = {
+    drawerLabel: 'HOME'
   };
 
   componentDidMount() {
@@ -76,7 +80,7 @@ class Home extends React.Component {
 
       // Maybe set app state and do something with it that way?
       // this.setState({ notification: notification });
-      
+
     } else if (notification.origin === 'received') {
       // notification was received, either app was already open or it just opened up but not from the notification
       // no way to tell which?
@@ -189,7 +193,7 @@ class DeferredHomeContent extends React.Component {
         </View>
         <View style={{ marginHorizontal: 15, flex: 1 }}>
           <SemiBoldText>Follow us</SemiBoldText>
-        </View>        
+        </View>
         <View flexDirection="row" style={{ paddingHorizontal: 20 }}>
           {socialButtons}
         </View>

--- a/src/screens/Roster.js
+++ b/src/screens/Roster.js
@@ -86,7 +86,7 @@ class PlayerRow extends React.Component {
 
 export default class Roster extends React.Component {
   static navigationOptions = {
-    title: Squads.roster_title,
+    headerTitle: Squads.roster_title,
     ...NavigationOptions
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -535,13 +535,6 @@ babel-plugin-transform-decorators-legacy@^1.3.4:
     babel-runtime "^6.2.0"
     babel-template "^6.3.0"
 
-babel-plugin-transform-define@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-define/-/babel-plugin-transform-define-1.3.0.tgz#94c5f9459c810c738cc7c50cbd44a31829d6f319"
-  dependencies:
-    lodash "4.17.4"
-    traverse "0.6.6"
-
 babel-plugin-transform-es2015-arrow-functions@^6.5.0, babel-plugin-transform-es2015-arrow-functions@^6.8.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz#452692cb711d5f79dc7f85e440ce41b9f244d221"
@@ -3087,13 +3080,13 @@ lodash.zipobject@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/lodash.zipobject/-/lodash.zipobject-4.1.3.tgz#b399f5aba8ff62a746f6979bf20b214f964dbef8"
 
-lodash@4.17.4, lodash@^4.0.0, lodash@^4.14.0, lodash@^4.16.6, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.6.1:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-
 lodash@^3.5.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+
+lodash@^4.0.0, lodash@^4.14.0, lodash@^4.16.6, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.6.1:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -3751,6 +3744,13 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@15.5.10:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+
 prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
@@ -3834,6 +3834,10 @@ react-devtools-core@^2.5.0:
     shell-quote "^1.6.1"
     ws "^2.0.3"
 
+react-lifecycles-compat@^1.0.2:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-1.1.4.tgz#fc005c72849b7ed364de20a0f64ff58ebdc2009a"
+
 react-mixin@^3.0.5:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/react-mixin/-/react-mixin-3.1.1.tgz#68749756bfe32699e561372a4aeecb926db72b7f"
@@ -3850,6 +3854,12 @@ react-native-animatable@^1.2.4:
 react-native-branch@2.0.0-beta.3:
   version "2.0.0-beta.3"
   resolved "https://registry.yarnpkg.com/react-native-branch/-/react-native-branch-2.0.0-beta.3.tgz#2167af86bbc9f964bd45bd5f37684e5b54965e32"
+
+react-native-deck-swiper@^1.4.8:
+  version "1.5.9"
+  resolved "https://registry.yarnpkg.com/react-native-deck-swiper/-/react-native-deck-swiper-1.5.9.tgz#0f18f51d9a1cb48c368e39433b1e5dce26135074"
+  dependencies:
+    prop-types "15.5.10"
 
 react-native-dismiss-keyboard@1.0.0:
   version "1.0.0"
@@ -3893,6 +3903,12 @@ react-native-resource-saving-container@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/react-native-resource-saving-container/-/react-native-resource-saving-container-1.0.2.tgz#e79f824829cff0e451eee2d61e417706f7436850"
 
+react-native-safe-area-view@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.7.0.tgz#38f5ab9368d6ef9e5d18ab64212938af3ec39421"
+  dependencies:
+    hoist-non-react-statics "^2.3.1"
+
 react-native-safe-module@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/react-native-safe-module/-/react-native-safe-module-1.2.0.tgz#a23824ca24edc2901913694a76646475113d570d"
@@ -3906,11 +3922,11 @@ react-native-safe-module@^1.1.0:
     color "^2.0.1"
     lodash "^4.16.6"
 
-react-native-tab-view@^0.0.70:
-  version "0.0.70"
-  resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-0.0.70.tgz#1dd2ded32acd0cb6bfef38d26e53675db733b37b"
+"react-native-tab-view@github:react-navigation/react-native-tab-view":
+  version "0.0.74"
+  resolved "https://codeload.github.com/react-navigation/react-native-tab-view/tar.gz/36ebd834d78b841fc19778c966465d02fd1213bb"
   dependencies:
-    prop-types "^15.5.10"
+    prop-types "^15.6.0"
 
 react-native-vector-icons@4.4.2:
   version "4.4.2"
@@ -3977,17 +3993,18 @@ react-native-vector-icons@4.4.2:
     xmldoc "^0.4.0"
     yargs "^9.0.0"
 
-react-navigation@1.0.0-beta.19:
-  version "1.0.0-beta.19"
-  resolved "https://registry.yarnpkg.com/react-navigation/-/react-navigation-1.0.0-beta.19.tgz#96e159c4b6760f51fc92d5c1c3690790cff4dbcf"
+react-navigation@1.5.11:
+  version "1.5.11"
+  resolved "https://registry.yarnpkg.com/react-navigation/-/react-navigation-1.5.11.tgz#fba6ab45d7b9987c1763a5aaac53b4f6d62b7f5c"
   dependencies:
-    babel-plugin-transform-define "^1.3.0"
     clamp "^1.0.1"
     hoist-non-react-statics "^2.2.0"
     path-to-regexp "^1.7.0"
     prop-types "^15.5.10"
+    react-lifecycles-compat "^1.0.2"
     react-native-drawer-layout-polyfill "^1.3.2"
-    react-native-tab-view "^0.0.70"
+    react-native-safe-area-view "^0.7.0"
+    react-native-tab-view "github:react-navigation/react-native-tab-view"
 
 react-proxy@^1.1.7:
   version "1.1.8"
@@ -4699,10 +4716,6 @@ tough-cookie@^2.3.2, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-
-traverse@0.6.6:
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
 
 trim-right@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This is a complete overhaul of the navigation to use more current features of `react-navigation`, specifically the `DrawerNavigator`. It should make adding screens much easier in the future. 

I think I have covered all of the typical flows of the app, particularly the Capo stuff (you can see the logic in `CustomerDrawer.js`), however it would be great for you guys to click through this to make sure I'm not missing something.