### PR TITLE
Refactor global state and methods

### DIFF
--- a/src/components/CustomDrawer.js
+++ b/src/components/CustomDrawer.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { Image, StyleSheet, View } from 'react-native';
 import { DrawerItems, NavigationActions, SafeAreaView } from 'react-navigation';
 import { Layout } from '../constants';
-import state from '../state';
 
 const CustomDrawer = props => (
   <View style={styles.container}>
@@ -25,7 +24,7 @@ const CustomDrawer = props => (
       labelStyle={{ color: 'white' }}
       onItemPress={({ route, focused }) => {
         if (route.routeName === 'CapoHome') {
-          if (state.unlocked === true) {
+          if (props.screenProps.unlocked === true) {
             props.navigation.navigate('CapoHome');
           } else {
             props.navigation.navigate('CapoLogin');

--- a/src/components/TalksUpNext.js
+++ b/src/components/TalksUpNext.js
@@ -11,8 +11,6 @@ import {
   getFeaturedSongs
 } from '../data';
 
-import state from '../state';
-
 import { BorderlessButton, RectButton } from 'react-native-gesture-handler';
 import { Ionicons } from '@expo/vector-icons';
 
@@ -85,22 +83,19 @@ export default class TalksUpNext extends React.Component {
         try {
           // if this is valid ??
           if (responseJson.song) {
-            console.log("server response song", JSON.stringify(responseJson.song.title));
-            
-            state.label = 'Up Next';
-            state.song = responseJson.song;
-
-            this.setState(previousState => {
-              return { label: 'Up Next', song: responseJson.song };
-            });
+            this.setState({ label: 'Up Next', song: responseJson.song });
           } else {
-            state.label = 'Featured Song';
-            state.song = getFeaturedSongs()[0];
+            this.setState({
+              label: 'Featured Song',
+              song: getFeaturedSongs()[0]
+            });
           }
         } catch (err) {
           // no data returns a json parsing error
-          state.label = 'Featured Song';
-          state.song = getFeaturedSongs()[0];
+          this.setState({
+            label: 'Featured Song',
+            song: getFeaturedSongs()[0]
+          });
         }
       });
 

--- a/src/screens/CapoComposeSong.js
+++ b/src/screens/CapoComposeSong.js
@@ -18,8 +18,6 @@ import { Ionicons } from '@expo/vector-icons';
 import LoadingPlaceholder from '../components/LoadingPlaceholder';
 import { BoldText, RegularText, SemiBoldText } from '../components/StyledText';
 
-import state from '../state';
-
 import Schema from '../data/song_schema';
 
 import { Colors, FontSizes, Layout } from '../constants';
@@ -88,7 +86,7 @@ export default class CapoComposeSong extends React.Component {
   };
 
   _handlePressContinueButton = () => {
-    state.currentSong = Schema;
+    this.props.screenProps.setCurrentSong(Schema);
     this.props.navigation.navigate('CapoConfirmSend');
   };
 }

--- a/src/screens/CapoConfirmSend.js
+++ b/src/screens/CapoConfirmSend.js
@@ -173,7 +173,7 @@ export default class CapoConfirmSend extends React.Component {
         //alert("success or fail message? do we even know?");
         // if fail, stay here
         // if success
-        this.props.navigation.navigate('Home');
+        this.props.navigation.popToTop();
       });
   };
 }

--- a/src/screens/CapoConfirmSend.js
+++ b/src/screens/CapoConfirmSend.js
@@ -17,8 +17,6 @@ import { Ionicons } from '@expo/vector-icons';
 import LoadingPlaceholder from '../components/LoadingPlaceholder';
 import { BoldText, RegularText, SemiBoldText } from '../components/StyledText';
 
-import state from '../state';
-
 import SongView from '../components/SongView';
 
 import { Colors, FontSizes, Layout } from '../constants';
@@ -54,18 +52,19 @@ export default class CapoConfirmSend extends React.Component {
   _getLocationAsync = async () => {
     let { status } = await Permissions.askAsync(Permissions.LOCATION);
     if (status !== 'granted') {
-      state.location = null;
+      this.props.screenProps.setLocation(null);
     } else {
       let location = await Location.getCurrentPositionAsync({});
-      state.location = location;
+      this.props.screenProps.setLocation(location);
     }
   };
 
   render() {
+    const { currentSong } = this.props.screenProps;
     return (
       <LoadingPlaceholder>
         <View style={styles.container}>
-          <SongView song={state.currentSong} />
+          <SongView song={currentSong} />
           <View style={styles.buttonContainer}>
             <ClipBorderRadius>
               <RectButton
@@ -125,18 +124,18 @@ export default class CapoConfirmSend extends React.Component {
   };
 
   _sendMessage = pushFlag => {
-    console.log('inside send', pushFlag);
+    const { currentSong, location, token } = this.props.screenProps;
 
-    CapoMessageSchema.sender = state.token;
+    CapoMessageSchema.sender = token;
     CapoMessageSchema.send_time = new Date();
-    if (null == state.location) {
+    if (null == location) {
       CapoMessageSchema.sender_latitude = '';
       CapoMessageSchema.sender_longitude = '';
     } else {
-      CapoMessageSchema.sender_latitude = state.location.coords.latitude;
-      CapoMessageSchema.sender_longitude = state.location.coords.longitude;
+      CapoMessageSchema.sender_latitude = location.coords.latitude;
+      CapoMessageSchema.sender_longitude = location.coords.longitude;
     }
-    CapoMessageSchema.song = state.currentSong;
+    CapoMessageSchema.song = currentSong;
     //console.log('---- object to wrap in a message to server ----\n', CapoMessageSchema);
 
     let notifications = new RemoteNotifications();

--- a/src/screens/CapoLogin.js
+++ b/src/screens/CapoLogin.js
@@ -10,7 +10,6 @@ import {
 import { RectButton } from 'react-native-gesture-handler';
 import { withNavigation } from 'react-navigation';
 import NavigationOptions from '../config/NavigationOptions';
-import state from '../state';
 import { BoldText, SemiBoldText } from '../components/StyledText';
 import { Colors, FontSizes } from '../constants';
 
@@ -29,6 +28,10 @@ export default class CapoLogin extends React.Component {
     ...NavigationOptions
   };
 
+  state = {
+    password: ''
+  };
+
   render() {
     return (
       <View style={styles.container}>
@@ -37,6 +40,7 @@ export default class CapoLogin extends React.Component {
           style={styles.textInput}
           autoFocus={true}
           onChangeText={this._setPassword}
+          value={this.state.value}
         />
         <ClipBorderRadius>
           <RectButton
@@ -51,13 +55,11 @@ export default class CapoLogin extends React.Component {
     );
   }
 
-  _setPassword = password => {
-    state.password = password;
-  };
+  _setPassword = password => this.setState({ password });
 
   _handlePressSubmitButton = () => {
-    if (state.password === '$4 beer') {
-      state.unlocked = true;
+    if (this.state.password === '$4 beer') {
+      this.props.screenProps.toggleUserAuth();
       this.props.navigation.navigate('CapoHome');
     }
   };

--- a/src/screens/CapoSelectSong.js
+++ b/src/screens/CapoSelectSong.js
@@ -19,7 +19,6 @@ import LoadingPlaceholder from '../components/LoadingPlaceholder';
 import Songs from '../data/songs.json';
 import Songbook from '../data/songbook.json';
 import { conferenceHasEnded } from '../utils/index';
-import state from '../state';
 
 import { find, propEq } from 'ramda';
 
@@ -125,7 +124,7 @@ export default class CapoSelectSong extends React.Component {
 
   _handlePressRow = item => {
     const song = find(propEq('_id', item._id), Songs);
-    state.currentSong = song;
+    this.props.screenProps.setCurrentSong(song);
 
     this.props.navigation.navigate('CapoConfirmSend');
   };

--- a/src/screens/Roster.js
+++ b/src/screens/Roster.js
@@ -16,8 +16,6 @@ import { NavigationActions } from 'react-navigation';
 import { BoldText, SemiBoldText, RegularText } from '../components/StyledText';
 import LoadingPlaceholder from '../components/LoadingPlaceholder';
 
-import state from '../state';
-
 import Players from '../data/players.json';
 import Squads from '../data/roster.json';
 

--- a/src/screens/Songbook.js
+++ b/src/screens/Songbook.js
@@ -25,8 +25,6 @@ import TableOfContentsInline from './TableOfContentsInline';
 import Songs from '../data/songs.json';
 import SongbookManifest from '../data/songbook.json';
 
-import state from '../state';
-
 const screenWidth = Dimensions.get('window').width;
 const firstValidPageIndex = 1;
 
@@ -172,29 +170,17 @@ export default class Songbook extends React.Component {
           </View>
           {songViews}
           <View style={{flex: 1, alignItems: 'center', justifyContent: 'center', width: screenWidth}}>
-            <TableOfContentsInline style={{width: screenWidth}} scrollToSong={this.scrollToSong} />
+            <TableOfContentsInline
+              style={{width: screenWidth}}
+              scrollToSong={this.scrollToSong}
+              setCurrentSong={this.props.screenProps.setCurrentSong}
+            />
           </View>
         </ScrollView>
         {tocButton}
         </View>
       </LoadingPlaceholder>
     );
-  };
-
-  _currentSong = () => {
-    return state.currentSong
-      ? songs.filter(song => song.song._id === state.currentSong._id)[0]
-      : undefined;
-  };
-
-  _currentPage = () => {
-    return state.currentSong
-      ? songs.filter(song => song.song._id === state.currentSong._id)[0].index
-      : 0;
-  };
-
-  _renderSong = ({ item }) => {
-    return <SongView song={item} />;
   };
 
   _handlePressTOCButton = () => {
@@ -219,8 +205,9 @@ export default class Songbook extends React.Component {
   };
 
   scrollToSong = () => {
-    this.setState({ tocButtonDisplay: true, chapter_title: state.currentSong.chapter_title });
-    this._scrollView.scrollTo({x: (state.currentSong.page - 1 + firstValidPageIndex) * screenWidth, y:0, animated:false});
+    const { currentSong } = this.props.screenProps;
+    this.setState({ tocButtonDisplay: true, chapter_title: currentSong.chapter_title });
+    this._scrollView.scrollTo({x: (currentSong.page - 1 + firstValidPageIndex) * screenWidth, y:0, animated:false});
   };
 
 }

--- a/src/screens/TableOfContentsInline.js
+++ b/src/screens/TableOfContentsInline.js
@@ -17,8 +17,6 @@ import { NavigationActions } from 'react-navigation';
 import { BoldText, SemiBoldText, RegularText } from '../components/StyledText';
 import LoadingPlaceholder from '../components/LoadingPlaceholder';
 
-import state from '../state';
-
 import Songs from '../data/songs.json';
 import Songbook from '../data/songbook.json';
 import { conferenceHasEnded } from '../utils/index';
@@ -31,14 +29,12 @@ import { find, propEq } from 'ramda';
 
 const screenWidth = Dimensions.get('window').width;
 
-console.log("Songbook ToC json: " + Songbook.songbook_title);
 
 let ToCData = [];
 let tocPageLabel = 1;
 Songbook.chapters.forEach(chapterChild => {
   let songList = [];
 
-  console.log(chapterChild.chapter_title);
   chapterChild.songs.forEach(songChild => {
     try {
       let song = {
@@ -46,7 +42,6 @@ Songbook.chapters.forEach(chapterChild => {
         song_title: Songs.filter(song => song._id === songChild._id)[0].title,
         page: tocPageLabel
       };
-      console.log(songChild._id + " " + song.song_title);
       // set page label
       song.toc_page_label = tocPageLabel;
       songList.push(song);
@@ -78,7 +73,9 @@ class SongRow extends React.Component {
         <View style={styles.row}>
           <View style={styles.rowData}>
             <RegularText>{song.song_title}</RegularText>
-            <RegularText style={styles.pageLabel}>{song.toc_page_label}</RegularText>
+            <RegularText style={styles.pageLabel}>
+              {song.toc_page_label}
+            </RegularText>
           </View>
         </View>
       </RectButton>
@@ -91,9 +88,7 @@ class SongRow extends React.Component {
 }
 
 export default class TableOfContentsInline extends React.Component {
-  state = {
-
-  };
+  state = {};
 
   render() {
     return (
@@ -126,18 +121,15 @@ export default class TableOfContentsInline extends React.Component {
 
   _handlePressRow = item => {
     const song = find(propEq('_id', item._id), Songs);
-    console.log('ToC inline song.title', song.title, item._id);
 
     // pass item page label to song to include in state
     song.page = item.toc_page_label;
 
-    state.currentSong = song;
-
-    // scroll to song
-    this.props.scrollToSong();
-
-    this.setState(previousState => {
-      return { currentSong: song };
+    this.props.setCurrentSong(song, () => {
+      this.props.scrollToSong();
+      this.setState(previousState => {
+        return { currentSong: song };
+      });
     });
   };
 }

--- a/src/state/index.js
+++ b/src/state/index.js
@@ -1,1 +1,0 @@
-export default {};


### PR DESCRIPTION
Refactor of the global `state` file that was previously being used.

This moves those global state fields to `App.js` and creates a few methods to control those field. Since we're using react-navigation, I'm passing those fields and methods through `screenProps`, which is available to any screen with navigation.

@galenriley If you could click through the app just to confirm it all works, that'd be great. Particularly sending out new songs.